### PR TITLE
fixed typos in python.config

### DIFF
--- a/.ebextensions/python.config
+++ b/.ebextensions/python.config
@@ -1,7 +1,7 @@
 option_settings:
-  aws:elasticbeanstalk:container:python:staticfiles
+  aws:elasticbeanstalk:container:python:staticfiles:
     /static/: static/
   aws:elasticbeanstalk:application:environment:
     FLASK_DEBUG: true
-	APP_VERSION: v1.2.0
-	ENABLE_COOL_NEW_FEATURE: false
+    APP_VERSION: v1.2.0
+    ENABLE_COOL_NEW_FEATURE: false


### PR DESCRIPTION
Replaced tabs with spaces so that it is not valid yaml
Added a colon
